### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Python Package using Conda
 
 on: [push]


### PR DESCRIPTION
Potential fix for [https://github.com/SherfeyInv/Fireworks/security/code-scanning/2](https://github.com/SherfeyInv/Fireworks/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to check out code and does not perform any write operations (such as creating issues, pushing code, or modifying pull requests), the minimal permission required is `contents: read`. This can be set at the workflow level (top-level, after the `name` and before `on`), which will apply to all jobs in the workflow. No changes to the steps or jobs are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
