### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package-condar.yml
+++ b/.github/workflows/python-package-condar.yml
@@ -1,5 +1,7 @@
 name: Python Package using Conda
 
+permissions:
+  contents: read
 on: [push]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/SherfeyInv/Fireworks/security/code-scanning/1](https://github.com/SherfeyInv/Fireworks/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN to the least privilege required. Since the workflow only checks out code and runs tests/linting, it does not require write access to repository contents, issues, or pull requests. The minimal required permission is `contents: read`. This block should be added at the root level of the workflow (above or below the `on:` block), so it applies to all jobs unless overridden. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
